### PR TITLE
Add Barefoot-sde to packagegroup and add README

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,20 @@
+Quick notes on meta-mion-sde.
+
+This layer requires you to have in ${MIONBASE} a directory named bf-sde.
+
+Within bf-sde should be the following:
+
+bf-reference-bsp-9.3.0-<MACHINE>.zip
+bf-reference-bsp-9.3.0.tgz
+bf-sde-9.3.0.tgz
+
+Once these are added to the directory you should:
+
+cd bf-sde
+git init
+git add .
+git commit -s -m"Adding reference bsp and sde"
+
+Eventually we'll use externalsrc, but for now this was easiest for
+me to get working.
+

--- a/meta-mion-barefoot/recipes-devtools/packagegroups/packagegroup-sde-barefoot.bb
+++ b/meta-mion-barefoot/recipes-devtools/packagegroups/packagegroup-sde-barefoot.bb
@@ -8,7 +8,7 @@ PACKAGES = ' \
 '
 
 RDEPENDS_packagegroup-sde-barefoot = "\
-  grpc bf-python bf-utils bf-syslibs bf-drivers procps bf-kdrv boost pi judy \
+  barefoot-bsp grpc bf-python bf-utils bf-syslibs bf-drivers procps bf-kdrv boost pi judy \
 "
 
 EXCLUDE_FROM_WORLD = "1"


### PR DESCRIPTION
Need a README for the bf-sde directory and we should now install the barefoot-sde package by default in the packagegroup