### PR TITLE
Add P4 Examples to Image

### DIFF
--- a/meta-mion-barefoot/recipes-extended/p4-examples/p4-examples_9.3.0.bb
+++ b/meta-mion-barefoot/recipes-extended/p4-examples/p4-examples_9.3.0.bb
@@ -1,0 +1,18 @@
+LICENSE = "CLOSED"
+
+SRC_URI = "git://${MIONBASE}/bf-sde"
+
+SRCREV = "${AUTOREV}"
+
+
+
+DEPENDS += " linux-yocto"
+
+S = "${WORKDIR}/${PN}-${PV}"
+
+FILES_${PN} += "${datadir}/p4/*"
+
+EXTRA_OECONF += " --datadir=${D}/usr/share"
+
+inherit autotools sde-package-extract
+


### PR DESCRIPTION
This may not be building the actual examples using the P4
compiler, but it does give us configuration files for
testing the functionality of the SDE using the `skip-p4`
profile.

Signed-off-by: G Davey <gdavey@committhis.co.uk>