### PR TITLE
Fix incorrect patch on bf-syslib log patch

### DIFF
--- a/meta-mion-barefoot/recipes-drivers/bf-syslibs/files/0001-Update-log-directory.patch
+++ b/meta-mion-barefoot/recipes-drivers/bf-syslibs/files/0001-Update-log-directory.patch
@@ -23,79 +23,79 @@ index 5f1f036..50ee25d 100644
  
  BF_SYS.ERROR >stdout;console_format
 -BF_SYS.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_SYS.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_SYS.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_LLD.ERROR >stdout;console_format
 -BF_LLD.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_LLD.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_LLD.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_PIPE.ERROR >stdout;console_format
 -BF_PIPE.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_PIPE.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_PIPE.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_TM.ERROR >stdout;console_format
 -BF_TM.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_TM.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_TM.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_MC.ERROR >stdout;console_format
 -BF_MC.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_MC.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_MC.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_PKT.ERROR >stdout;console_format
 -BF_PKT.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_PKT.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_PKT.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_DVM.ERROR >stdout;console_format
 -BF_DVM.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_DVM.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_DVM.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_PORT.ERROR >stdout;console_format
 -BF_PORT.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_PORT.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_PORT.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_AVAGO.ERROR >stdout;console_format
 -BF_AVAGO.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_AVAGO.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_AVAGO.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_DRU.ERROR >stdout;console_format
 -BF_DRU.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_DRU.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_DRU.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_API.ERROR >stdout;console_format
 -BF_API.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_API.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_API.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_SAI.ERROR >stdout;console_format
 -BF_SAI.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_SAI.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_SAI.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_PI.ERROR >stdout;console_format
 -BF_PI.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_PI.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_PI.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_PLTFM.ERROR >stdout;console_format
 -BF_PLTFM.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_PLTFM.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_PLTFM.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_PAL.ERROR >stdout;console_format
 -BF_PAL.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_PAL.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_PAL.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_PM.ERROR >stdout;console_format
 -BF_PM.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_PM.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_PM.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_KNET.ERROR >stdout;console_format
 -BF_KNET.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_KNET.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_KNET.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_BFRT.ERROR >stdout;console_format
 -BF_BFRT.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_BFRT.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_BFRT.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  BF_P4RT.ERROR >stdout;console_format
 -BF_P4RT.DEBUG "bf_drivers.log", 5M * 5 ;file_format
-+BF_P4RT.DEBUG "/var/log/ptne/bf_drivers.log", 5M * 5 ;file_format
++BF_P4RT.DEBUG "/var/log/bf_drivers.log", 5M * 5 ;file_format
  
  *.ERROR	 >syslog , LOG_USER
  


### PR DESCRIPTION
Signed-off-by: John Toomey <john@toganlabs.com>

# meta-mion-sde

## Summary
- Description: fix the path in the patch to something that actually exists
- Affected hardware: Barefoot SDE systems
- Issue: #17 

## Build and test
- [x] Build command: time ../cronie.sh -m stordis-bf6064x-t mion-onie-image-onlpv1
- [x] Smoke tested on: stordis bf6064