### PR TITLE
barefoot-sde_9.4.0.bb: Remove APSN specific extract

### DIFF
--- a/meta-mion-barefoot/recipes-drivers/barefoot-bsp/barefoot-bsp_9.4.0.bb
+++ b/meta-mion-barefoot/recipes-drivers/barefoot-bsp/barefoot-bsp_9.4.0.bb
@@ -42,19 +42,6 @@ extract() {
     ./extract_all.sh
     cd ${SRC}
     unzip ${SRC}/${BSP_PLATFORM_CODE}.zip -d ${SRC}/bf-platforms-${SDE_VERSION}
-    cd ${SRC}/bf-platforms-${SDE_VERSION}
-    #patch -p1 < ./platforms/bf2556x_1t.diff
-
-    # There is a bunch of cruft in how this is packaged.
-    # Removing all the cruft
-    find ${S} -name Makefile.in -delete
-    find ${S} -name Makefile -delete
-    find ${S} -name "*.o" -delete
-    find ${S} -name ".deps" -exec rm -rv {} +
-    find ${S} -name ".libs" -exec rm -rv {} +
-    find ${S} -name "*.la" -delete
-    find ${S} -name "*.lo" -delete
-    rm ${S}/configure
 }
 
 do_configure_prepend() {


### PR DESCRIPTION
There is a patch apsn requires. Remove this into their BSP

Signed-off-by: Eilís Ní Fhlannagáin <pidge@toganlabs.com>

# meta-mion-sde

## Summary
- Description: _brief description of the bug that was fixed or the enhancement that was added_
- Affected hardware: _ALL -or- list specific switches_
- Issue: _#?_

## Build and test
- [ ] Build command: _e.g. mc_build.sh ..._
- [ ] Smoke tested on: _e.g. stordis bf2556x-1t_
- [ ] _all other steps taken to validate the pull request_

## Checklist
- [ ] All relevant issues have been updated
- [ ] Reviewers have been added and a maintainer has been assigned
- [ ] A Label, Project and Milestone have all been added
- [ ] The relevant documentation/wiki/README have been updated and complies with the [NGL Style and Communication Guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide)
- [ ] Git commits comply with the [NGL Git Workflow](https://github.com/NetworkGradeLinux/mion-docs/wiki/Git-Workflow) and have DCO signoff
- [ ] Yocto code complies with the [OpenEmbedded Style Guide](https://www.openembedded.org/wiki/Styleguide)
